### PR TITLE
Updated SignalRIoCScopeSample with InstancePerLifetimeScope example

### DIFF
--- a/SignalRIoCScopeSample/.nuget/NuGet.Config
+++ b/SignalRIoCScopeSample/.nuget/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <solution>
+    <add key="disableSourceControlIntegration" value="true" />
+  </solution>
+</configuration>

--- a/SignalRIoCScopeSample/.nuget/NuGet.targets
+++ b/SignalRIoCScopeSample/.nuget/NuGet.targets
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">$(MSBuildProjectDirectory)\..\</SolutionDir>
+        
+        <!-- Enable the restore command to run before builds -->
+        <RestorePackages Condition="  '$(RestorePackages)' == '' ">false</RestorePackages>
+
+        <!-- Property that enables building a package from a project -->
+        <BuildPackage Condition=" '$(BuildPackage)' == '' ">false</BuildPackage>
+
+        <!-- Determines if package restore consent is required to restore packages -->
+        <RequireRestoreConsent Condition=" '$(RequireRestoreConsent)' != 'false' ">true</RequireRestoreConsent>
+        
+        <!-- Download NuGet.exe if it does not already exist -->
+        <DownloadNuGetExe Condition=" '$(DownloadNuGetExe)' == '' ">false</DownloadNuGetExe>
+    </PropertyGroup>
+    
+    <ItemGroup Condition=" '$(PackageSources)' == '' ">
+        <!-- Package sources used to restore packages. By default, registered sources under %APPDATA%\NuGet\NuGet.Config will be used -->
+        <!-- The official NuGet package source (https://nuget.org/api/v2/) will be excluded if package sources are specified and it does not appear in the list -->
+        <!--
+            <PackageSource Include="https://nuget.org/api/v2/" />
+            <PackageSource Include="https://my-nuget-source/nuget/" />
+        -->
+    </ItemGroup>
+
+    <PropertyGroup Condition=" '$(OS)' == 'Windows_NT'">
+        <!-- Windows specific commands -->
+        <NuGetToolsPath>$([System.IO.Path]::Combine($(SolutionDir), ".nuget"))</NuGetToolsPath>
+        <PackagesConfig>$([System.IO.Path]::Combine($(ProjectDir), "packages.config"))</PackagesConfig>
+    </PropertyGroup>
+    
+    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT'">
+        <!-- We need to launch nuget.exe with the mono command if we're not on windows -->
+        <NuGetToolsPath>$(SolutionDir).nuget</NuGetToolsPath>
+        <PackagesConfig>packages.config</PackagesConfig>
+    </PropertyGroup>
+    
+    <PropertyGroup>
+        <!-- NuGet command -->
+        <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\NuGet.exe</NuGetExePath>
+        <PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources>
+        
+        <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>
+        <NuGetCommand Condition=" '$(OS)' != 'Windows_NT' ">mono --runtime=v4.0.30319 $(NuGetExePath)</NuGetCommand>
+
+        <PackageOutputDir Condition="$(PackageOutputDir) == ''">$(TargetDir.Trim('\\'))</PackageOutputDir>
+        
+        <RequireConsentSwitch Condition=" $(RequireRestoreConsent) == 'true' ">-RequireConsent</RequireConsentSwitch>
+        <NonInteractiveSwitch Condition=" '$(VisualStudioVersion)' != '' AND '$(OS)' == 'Windows_NT' ">-NonInteractive</NonInteractiveSwitch>
+        
+        <!-- Commands -->
+        <RestoreCommand>$(NuGetCommand) install "$(PackagesConfig)" -source "$(PackageSources)"  $(NonInteractiveSwitch) $(RequireConsentSwitch) -solutionDir "$(SolutionDir) " </RestoreCommand>
+        <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties Configuration=$(Configuration) $(NonInteractiveSwitch) -OutputDirectory "$(PackageOutputDir)" -symbols</BuildCommand>
+
+        <!-- We need to ensure packages are restored prior to assembly resolve -->
+        <BuildDependsOn Condition="$(RestorePackages) == 'true'">
+            RestorePackages;
+            $(BuildDependsOn);
+        </BuildDependsOn>
+
+        <!-- Make the build depend on restore packages -->
+        <BuildDependsOn Condition="$(BuildPackage) == 'true'">
+            $(BuildDependsOn);
+            BuildPackage;
+        </BuildDependsOn>
+    </PropertyGroup>
+
+    <Target Name="CheckPrerequisites">
+        <!-- Raise an error if we're unable to locate nuget.exe  -->
+        <Error Condition="'$(DownloadNuGetExe)' != 'true' AND !Exists('$(NuGetExePath)')" Text="Unable to locate '$(NuGetExePath)'" />
+        <!--
+        Take advantage of MsBuild's build dependency tracking to make sure that we only ever download nuget.exe once.
+        This effectively acts as a lock that makes sure that the download operation will only happen once and all
+        parallel builds will have to wait for it to complete.
+        -->
+        <MsBuild Targets="_DownloadNuGet" Projects="$(MSBuildThisFileFullPath)" Properties="Configuration=NOT_IMPORTANT;DownloadNuGetExe=$(DownloadNuGetExe)" />
+    </Target>
+
+    <Target Name="_DownloadNuGet">
+        <DownloadNuGet OutputFilename="$(NuGetExePath)" Condition=" '$(DownloadNuGetExe)' == 'true' AND !Exists('$(NuGetExePath)')" />
+    </Target>
+
+    <Target Name="RestorePackages" DependsOnTargets="CheckPrerequisites">
+        <Exec Command="$(RestoreCommand)"
+              Condition="'$(OS)' != 'Windows_NT' And Exists('$(PackagesConfig)')" />
+              
+        <Exec Command="$(RestoreCommand)"
+              LogStandardErrorAsError="true"
+              Condition="'$(OS)' == 'Windows_NT' And Exists('$(PackagesConfig)')" />
+    </Target>
+
+    <Target Name="BuildPackage" DependsOnTargets="CheckPrerequisites">
+        <Exec Command="$(BuildCommand)" 
+              Condition=" '$(OS)' != 'Windows_NT' " />
+              
+        <Exec Command="$(BuildCommand)"
+              LogStandardErrorAsError="true"
+              Condition=" '$(OS)' == 'Windows_NT' " />
+    </Target>
+    
+    <UsingTask TaskName="DownloadNuGet" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+        <ParameterGroup>
+            <OutputFilename ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Reference Include="System.Core" />
+            <Using Namespace="System" />
+            <Using Namespace="System.IO" />
+            <Using Namespace="System.Net" />
+            <Using Namespace="Microsoft.Build.Framework" />
+            <Using Namespace="Microsoft.Build.Utilities" />
+            <Code Type="Fragment" Language="cs">
+                <![CDATA[
+                try {
+                    OutputFilename = Path.GetFullPath(OutputFilename);
+
+                    Log.LogMessage("Downloading latest version of NuGet.exe...");
+                    WebClient webClient = new WebClient();
+                    webClient.DownloadFile("https://nuget.org/nuget.exe", OutputFilename);
+
+                    return true;
+                }
+                catch (Exception ex) {
+                    Log.LogErrorFromException(ex);
+                    return false;
+                }
+            ]]>
+            </Code>
+        </Task>
+    </UsingTask>
+</Project>

--- a/SignalRIoCScopeSample/SignalRIoCScopeSample.sln
+++ b/SignalRIoCScopeSample/SignalRIoCScopeSample.sln
@@ -3,6 +3,13 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SignalRIoCScopeSample", "SignalRIoCScopeSample\SignalRIoCScopeSample.csproj", "{B98B31B2-93EB-4402-92F9-3A469E13515D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{2D13FA58-4A10-4115-B4BA-48B224491CC9}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/SignalRIoCScopeSample/SignalRIoCScopeSample/Global.asax.cs
+++ b/SignalRIoCScopeSample/SignalRIoCScopeSample/Global.asax.cs
@@ -27,12 +27,10 @@ namespace SignalRIoCScopeSample
                 ContractResolver = new CamelCasePropertyNamesContractResolver()
             });
 
-            // With this implementation, I create a new instance of Broadcaster
-            // of every Resolve call to container which is not what I want.
-            // I wanna share the Broadcaster instance throughout the Hub invocation.
-            builder.RegisterType<Broadcaster>().As<IBroadcaster>();
-            builder.RegisterType<Foo>().As<IFoo>();
-            builder.RegisterType<Bar>().As<IBar>();
+            // The hub will create a lifetime scope manually in its constructor to resolve the IFoo and IBar services.
+            builder.RegisterType<Broadcaster>().As<IBroadcaster>().InstancePerLifetimeScope();
+            builder.RegisterType<Foo>().As<IFoo>().InstancePerLifetimeScope();
+            builder.RegisterType<Bar>().As<IBar>().InstancePerLifetimeScope();
 
             builder.Register(c => serializer).As<JsonSerializer>();
             return builder.Build();

--- a/SignalRIoCScopeSample/SignalRIoCScopeSample/PingHub.cs
+++ b/SignalRIoCScopeSample/SignalRIoCScopeSample/PingHub.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNet.SignalR;
+﻿using Autofac;
+using Microsoft.AspNet.SignalR;
 
 namespace SignalRIoCScopeSample
 {
@@ -6,17 +7,32 @@ namespace SignalRIoCScopeSample
     {
         private readonly IBar _bar;
         private readonly IFoo _foo;
+        private readonly ILifetimeScope _hubLifetimeScope;
 
-        public PingHub(IBar bar, IFoo foo)
+        public PingHub(ILifetimeScope lifetimeScope)
         {
-            _bar = bar;
-            _foo = foo;
+            // Create a lifetime scope for this hub instance.
+            _hubLifetimeScope = lifetimeScope.BeginLifetimeScope();
+
+            // Resolve the dependencies from the hub lifetime scope (unfortunately, service locator style).
+            _bar = _hubLifetimeScope.Resolve<IBar>();
+            _foo = _hubLifetimeScope.Resolve<IFoo>();
         }
 
         public void Ping()
         {
             Clients.All.pinged("Pinged for IBar: " + _bar.Broadcast().ToString("MM/dd/yyyy hh:mm:ss.fff tt"));
             Clients.All.pinged("Pinged for IFoo: " + _foo.Broadcast().ToString("MM/dd/yyyy hh:mm:ss.fff tt"));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            // When SignalR disposes the hub clean up the lifetime scope.
+            if (disposing && _hubLifetimeScope != null)
+            {
+                _hubLifetimeScope.Dispose();
+            }
+            base.Dispose(disposing);
         }
     }
 }

--- a/SignalRIoCScopeSample/SignalRIoCScopeSample/SignalRIoCScopeSample.csproj
+++ b/SignalRIoCScopeSample/SignalRIoCScopeSample/SignalRIoCScopeSample.csproj
@@ -19,6 +19,8 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -141,6 +143,7 @@
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
+  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Provided an example of `InstancePerLifetimeScope` (instance per hub) using service location through `ILifetimeScope` injected into hub instance. Also enabled NuGet package restore on the SignalRIoCScopeSample.
